### PR TITLE
Add currency formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ var makeNumberObject = makeArgumentString(function makeNumberObject(str) {
 			if (typeof precision === 'number') {
 				return self.changePrecision(precision, roundingStrategy).toString()
 			}
+			if (typeof precision === 'object') {
+	      return self.format(precision)
+	    }
 			return str
 		},
 		changePrecision: function changePrecision(precision, roundingStrategy) {
@@ -47,7 +50,34 @@ var makeNumberObject = makeArgumentString(function makeNumberObject(str) {
 		},
 		lte: function lessThanOrEqualTo(otherSide) {
 			return !self.gt(otherSide)
-		}
+		},
+		format: function format(props) {
+	    props.decimal_places = props.decimal_places === undefined ? 2 : props.decimal_places
+	    props.decimal_separator = props.decimal_separator || '.'
+	    props.thousands_separator = props.thousands_separator || ','
+	    props.currency_symbol = props.currency_symbol || '$'
+
+	    var parts = self.changePrecision(props.decimal_places, props.rounding_strategy).toString().split('.')
+	    var units = self.isNegative() ? parts[0].slice(1) : parts[0]
+	    var decimals = (parts.length > 1) ? parts[1] : null
+
+	    var groupedUnits = ''
+	    for (var i = units.length; i > 3; i -= 3) {
+	      groupedUnits = props.thousands_separator + units.slice(i-3, i) + groupedUnits
+	    }
+	    groupedUnits = units.slice(0, i) + groupedUnits
+	    if (decimals) {
+	      groupedUnits += props.decimal_separator + decimals
+	    }
+	    var formattedString = self.isNegative() ? '-' : ''
+	    if (!props.symbol_last) {
+	      formattedString = props.negative_after_currency ? props.currency_symbol + formattedString : formattedString + props.currency_symbol
+	    }
+	    formattedString += groupedUnits
+	    formattedString = props.symbol_last ? formattedString + props.currency_symbol : formattedString
+
+	    return formattedString
+	  }
 	}
 
 	return self

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ var makeNumberObject = makeArgumentString(function makeNumberObject(str) {
 			return !self.gt(otherSide)
 		},
 		format: function format(props) {
+			props = props || {}
 	    props.decimal_places = props.decimal_places === undefined ? 2 : props.decimal_places
 	    props.decimal_separator = props.decimal_separator || '.'
 	    props.thousands_separator = props.thousands_separator || ','

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,10 @@ By default, numbers will be trimmed - `number('114.9885').toString(2)` will retu
 
 If you prefer rounding, you can pass in the provided rounding strategy: `number('114.9885').toString(2, number.round)` will produce `114.99`.
 
+You can also call `format` with an object defining more extensive currency formatting options (this can also be passed to `toString` for the same result).
+
+Use a blank object for a default currency format - `number('123456').format()` will return `$123,456.00`.
+
 If your business requirements call for a different rounding strategy, you can provide your own.  I would be happy to help you write it if you [open an issue](https://github.com/TehShrike/financial-arithmeticator/issues).
 
 #### For calculation purposes
@@ -108,6 +112,22 @@ Returns a string representation of the number for display or storage.  You can s
 
 ```js
 number('99.99').toString() // => '99.99'
+```
+
+#### `numberValue.format([formatObject])` or `numberValue.toString(formatObject)`
+
+Returns a formatted string representation of the number for currency display. You can specify the following properties (all of which are optional):
+- `decimal_places`: The number of decimal places to change precision to (*default: `2`*)
+- `rounding_strategy`: The rounding strategy to use when changing precision (*default: `number.trim`*)
+- `currency_symbol`: The currency symbol (*default: `,`*)
+- `symbol_last`: Whether the currency symbol should be placed after the digits (*default: `false`*)
+- `thousands_separator`: The thousands grouping separator (*default: `,`*)
+- `decimal_separator`: The decimal place separator (*default: `.`*)
+- `negative_after_currency`: Whether the negative symbol should be placed after the currency symbol when at it is displayed before the digits (*default: `false`, has no effect if `symbol_last` is falsy*)
+
+
+```js
+number('-123456.99').format() // => '-$123,456.99'
 ```
 
 #### `numberValue.getPrecision()`

--- a/test/test.js
+++ b/test/test.js
@@ -43,8 +43,6 @@ test('getPrecision', function(t) {
 test('equality', function(t) {
 	t.ok(number('13').equal('13.000'))
 	t.notOk(number('13').equal('13.0000000001'))
-	t.ok(number('13.000').equal('13'))
-	t.notOk(number('13.0000000001').equal('13'))
 	t.ok(number('13').equal('13'))
 	t.ok(number('000013').equal('13.000'))
 
@@ -96,4 +94,15 @@ test('changing precision by rounding', function(t) {
 	t.equal(number('-5.64').changePrecision(4, number.round).toString(), '-5.6400', 'negative number: precision increasing')
 
 	t.end()
+})
+
+test('formatted toString', function(t) {
+	t.equal(number('-12345678.9').format({}), '-$12,345,678.90', 'default formatting')
+	t.equal(number('-12345678.9').format({negative_after_currency: true}), '$-12,345,678.90', 'negative symbol after currency symbol')
+	t.equal(number('-12345678.9').format({symbol_last: true}), '-12,345,678.90$', 'currency symbol after number')
+	t.equal(number('-12345678.9').format({symbol_last: true, negative_after_currency: true}), '-12,345,678.90$', 'negative symbol 	still at front with currency symbol after number')
+
+
+
+
 })

--- a/test/test.js
+++ b/test/test.js
@@ -96,13 +96,20 @@ test('changing precision by rounding', function(t) {
 	t.end()
 })
 
-test('formatted toString', function(t) {
+test('currency formatting', function(t) {
 	t.equal(number('-12345678.9').format({}), '-$12,345,678.90', 'default formatting')
 	t.equal(number('-12345678.9').format({negative_after_currency: true}), '$-12,345,678.90', 'negative symbol after currency symbol')
 	t.equal(number('-12345678.9').format({symbol_last: true}), '-12,345,678.90$', 'currency symbol after number')
-	t.equal(number('-12345678.9').format({symbol_last: true, negative_after_currency: true}), '-12,345,678.90$', 'negative symbol 	still at front with currency symbol after number')
+	t.equal(number('-12345678.9').format({symbol_last: true, negative_after_currency: true}), '-12,345,678.90$', 'negative symbol still at front with currency symbol after number')
+	t.equal(number('-12345678.9').format({thousands_separator: '+', decimal_separator: '^', currency_symbol: '@'}), '-@12+345+678^90', 'user-defined currency symbol and separators')
+	t.equal(number('-12345678.9').format({decimal_places: 3}), '-$12,345,678.900', 'precision no rounding')
+	t.equal(number('-12345678.09').format({decimal_places: 1, rounding_strategy: number.round}), '-$12,345,678.1', 'precision with rounding')
+	t.equal(number('-12345678.009').format({rounding_strategy: number.round}), '-$12,345,678.01', 'no precision with rounding')
+	t.equal(number('-12345678.98').format({decimal_places: 0}), '-$12,345,678', 'no decimal places with no rounding')
+	t.equal(number('-12345678.98').format({decimal_places: 0, rounding_strategy: number.round}), '-$12,345,679', 'no decimal places with rounding')
 
+t.equal(number('-12345678.9').format(), '-$12,345,678.90', 'no format object')
+	t.equal(number('-12345678.9').toString({}), '-$12,345,678.90', 'default formatting using `toString` as a shortcut')
 
-
-
+	t.end()
 })


### PR DESCRIPTION
This adds a `format` method, as well as overloading `toString` to optionally take an object and forward it through to the `format` method. Leaving the object blank will give a reasonable default (`-$123,456.78`)

Formatting options:
- decimal places
- rounding strategy
- currency symbol
- whether the symbol is placed before or after digits
- whether the negative symbol is placed before or after the currency symbol
- thousands separator
- decimal separator